### PR TITLE
feat!: migrate from js-yaml to yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,10 @@
     "esbuild": ">=0.19.0"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@luxass/eslint-config": "^4.14.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.17.5",
     "esbuild": "^0.24.0",
     "eslint": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,13 @@ importers:
 
   .:
     dependencies:
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+      yaml:
+        specifier: ^2.7.0
+        version: 2.7.0
     devDependencies:
       '@luxass/eslint-config':
         specifier: ^4.14.0
         version: 4.14.0(@typescript-eslint/utils@8.16.0(eslint@9.17.0)(typescript@5.7.2))(@vue/compiler-sfc@3.4.31)(eslint-plugin-format@0.1.3(eslint@9.17.0))(eslint@9.17.0)(typescript@5.7.2)(vitest@2.1.8(@types/node@20.17.11))
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^20.17.5
         version: 20.17.11
@@ -35,7 +32,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(postcss@8.4.49)(typescript@5.7.2)(yaml@2.5.0)
+        version: 8.3.5(postcss@8.4.49)(typescript@5.7.2)(yaml@2.7.0)
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -638,9 +635,6 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2206,8 +2200,8 @@ packages:
     resolution: {integrity: sha512-4wZWvE398hCP7O8n3nXKu/vdq1HcH01ixYlCREaJL5NUMwQ0g3MaGFUBNSlmBtKmhbtVG/Cm6lyYmSVTEVil8A==}
     engines: {node: ^14.17.0 || >=16.0.0}
 
-  yaml@2.5.0:
-    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -2653,8 +2647,6 @@ snapshots:
       '@types/ms': 0.7.34
 
   '@types/estree@1.0.6': {}
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4030,12 +4022,12 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.4.49)(yaml@2.5.0):
+  postcss-load-config@6.0.1(postcss@8.4.49)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
       postcss: 8.4.49
-      yaml: 2.5.0
+      yaml: 2.7.0
 
   postcss-selector-parser@6.1.1:
     dependencies:
@@ -4290,7 +4282,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.5(postcss@8.4.49)(typescript@5.7.2)(yaml@2.5.0):
+  tsup@8.3.5(postcss@8.4.49)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.2)
       cac: 6.7.14
@@ -4300,7 +4292,7 @@ snapshots:
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.4.49)(yaml@2.5.0)
+      postcss-load-config: 6.0.1(postcss@8.4.49)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.28.1
       source-map: 0.8.0-beta.0
@@ -4481,9 +4473,9 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
       lodash: 4.17.21
-      yaml: 2.5.0
+      yaml: 2.7.0
 
-  yaml@2.5.0: {}
+  yaml@2.7.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 import type { Plugin } from "esbuild";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import yaml, { type LoadOptions } from "js-yaml";
+import { type DocumentOptions, parse, type ParseOptions, type SchemaOptions, type ToJSOptions } from "yaml";
 
 export interface YAMLPluginOptions {
   /**
    * Options to pass to the YAML parser.
    * @see https://github.com/nodeca/js-yaml
    */
-  parserOptions?: LoadOptions;
+  parserOptions?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions;
 }
 
 export function YAMLPlugin({ parserOptions }: YAMLPluginOptions = {}): Plugin {
@@ -27,7 +27,7 @@ export function YAMLPlugin({ parserOptions }: YAMLPluginOptions = {}): Plugin {
       build.onLoad({ filter: /\.ya?ml$/, namespace: "yaml" }, async (args) => {
         const yamlContent = await readFile(args.path, "utf8");
 
-        const parsed = yaml.load(yamlContent, parserOptions);
+        const parsed = parse(yamlContent, parserOptions);
         return {
           loader: "json",
           contents: JSON.stringify(parsed),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -16,7 +16,7 @@ it("expect yaml import to be a json object", async () => {
       import YAMLConfig from "./yaml-config.yaml";
       console.log(YAMLConfig);
     `),
-      YAMLPlugin(),
+      YAMLPlugin({}),
     ],
   });
 
@@ -24,7 +24,7 @@ it("expect yaml import to be a json object", async () => {
 
   expect(text).toMatchInlineSnapshot(`
   "var yaml_config_default = { pluginDir: "./plugins", web: { enabled: true }, logging: { type: "stdout", level: "info" } };
-  
+
   console.log(yaml_config_default);
   "
   `);
@@ -77,7 +77,7 @@ it("expect yml import to be a json object", async () => {
 
   expect(text).toMatchInlineSnapshot(`
   "var yml_config_default = { pluginDir: "./plugins", web: { enabled: true }, logging: { type: "stdout", level: "info" } };
-  
+
   console.log(yml_config_default);
   "
   `);


### PR DESCRIPTION
js-yaml hasn't been updated in the last three or so years, which yaml has.

This upgrade will also allow us to support yaml 1.1, and has better support for comments.